### PR TITLE
Adds new airframe with camera and new world with aruco markers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -78,7 +78,7 @@
 	branch = px4
 [submodule "Tools/simulation/gz"]
 	path = Tools/simulation/gz
-	url = https://github.com/hugo2410/PX4-gazebo-models.git
+	url = git@github.com:hugo2410/PX4-gazebo-models.git
 	branch = main
 [submodule "boards/modalai/voxl2/libfc-sensor-api"]
 	path = boards/modalai/voxl2/libfc-sensor-api

--- a/.gitmodules
+++ b/.gitmodules
@@ -78,7 +78,7 @@
 	branch = px4
 [submodule "Tools/simulation/gz"]
 	path = Tools/simulation/gz
-	url = https://github.com/PX4/PX4-gazebo-models.git
+	url = https://github.com/hugo2410/PX4-gazebo-models.git
 	branch = main
 [submodule "boards/modalai/voxl2/libfc-sensor-api"]
 	path = boards/modalai/voxl2/libfc-sensor-api

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4099_gz_x500_custom_cam
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4099_gz_x500_custom_cam
@@ -5,53 +5,11 @@
 # @type Quadrotor
 #
 
-. ${R}etc/init.d/rc.mc_defaults
 
-PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
-PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
-PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500}
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500_custom_cam}
 
-param set-default SIM_GZ_EN 1
+. ${R}etc/init.d-posix/airframes/4001_gz_x500
 
-param set-default SENS_EN_GPSSIM 1
-param set-default SENS_EN_BAROSIM 0
-param set-default SENS_EN_MAGSIM 1
-
-param set-default CA_AIRFRAME 0
-param set-default CA_ROTOR_COUNT 4
-
-param set-default CA_ROTOR0_PX 0.13
-param set-default CA_ROTOR0_PY 0.22
-param set-default CA_ROTOR0_KM  0.05
-
-param set-default CA_ROTOR1_PX -0.13
-param set-default CA_ROTOR1_PY -0.20
-param set-default CA_ROTOR1_KM  0.05
-
-param set-default CA_ROTOR2_PX 0.13
-param set-default CA_ROTOR2_PY -0.22
-param set-default CA_ROTOR2_KM -0.05
-
-param set-default CA_ROTOR3_PX -0.13
-param set-default CA_ROTOR3_PY 0.20
-param set-default CA_ROTOR3_KM -0.05
-
-param set-default SIM_GZ_EC_FUNC1 101
-param set-default SIM_GZ_EC_FUNC2 102
-param set-default SIM_GZ_EC_FUNC3 103
-param set-default SIM_GZ_EC_FUNC4 104
-
-param set-default SIM_GZ_EC_MIN1 150
-param set-default SIM_GZ_EC_MIN2 150
-param set-default SIM_GZ_EC_MIN3 150
-param set-default SIM_GZ_EC_MIN4 150
-
-param set-default SIM_GZ_EC_MAX1 1000
-param set-default SIM_GZ_EC_MAX2 1000
-param set-default SIM_GZ_EC_MAX3 1000
-param set-default SIM_GZ_EC_MAX4 1000
-
-param set-default MPC_THR_HOVER 0.60
 param set-default NAV_DLL_ACT 0
 param set-default COM_RC_IN_MODE 4
 param set-default COM_RCL_EXCEPT 4

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4099_gz_x500_custom_cam
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4099_gz_x500_custom_cam
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+# @name Gazebo x500 custom cam
+#
+# @type Quadrotor
+#
+
+. ${R}etc/init.d/rc.mc_defaults
+
+PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
+PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500}
+
+param set-default SIM_GZ_EN 1
+
+param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_BAROSIM 0
+param set-default SENS_EN_MAGSIM 1
+
+param set-default CA_AIRFRAME 0
+param set-default CA_ROTOR_COUNT 4
+
+param set-default CA_ROTOR0_PX 0.13
+param set-default CA_ROTOR0_PY 0.22
+param set-default CA_ROTOR0_KM  0.05
+
+param set-default CA_ROTOR1_PX -0.13
+param set-default CA_ROTOR1_PY -0.20
+param set-default CA_ROTOR1_KM  0.05
+
+param set-default CA_ROTOR2_PX 0.13
+param set-default CA_ROTOR2_PY -0.22
+param set-default CA_ROTOR2_KM -0.05
+
+param set-default CA_ROTOR3_PX -0.13
+param set-default CA_ROTOR3_PY 0.20
+param set-default CA_ROTOR3_KM -0.05
+
+param set-default SIM_GZ_EC_FUNC1 101
+param set-default SIM_GZ_EC_FUNC2 102
+param set-default SIM_GZ_EC_FUNC3 103
+param set-default SIM_GZ_EC_FUNC4 104
+
+param set-default SIM_GZ_EC_MIN1 150
+param set-default SIM_GZ_EC_MIN2 150
+param set-default SIM_GZ_EC_MIN3 150
+param set-default SIM_GZ_EC_MIN4 150
+
+param set-default SIM_GZ_EC_MAX1 1000
+param set-default SIM_GZ_EC_MAX2 1000
+param set-default SIM_GZ_EC_MAX3 1000
+param set-default SIM_GZ_EC_MAX4 1000
+
+param set-default MPC_THR_HOVER 0.60
+param set-default NAV_DLL_ACT 0
+param set-default COM_RC_IN_MODE 4
+param set-default COM_RCL_EXCEPT 4

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -83,6 +83,11 @@ px4_add_romfs_files(
 	4009_gz_r1_rover
 	4010_gz_x500_mono_cam
 	4011_gz_lawnmower
+	4012_gz_rover_ackermann
+	4013_gz_x500_lidar
+	4014_gz_x500_mono_cam_down
+	4015_gz_r1_rover_mecanum
+	4099_gz_x500_custom_cam
 
 	6011_gazebo-classic_typhoon_h480
 	6011_gazebo-classic_typhoon_h480.post

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -83,10 +83,6 @@ px4_add_romfs_files(
 	4009_gz_r1_rover
 	4010_gz_x500_mono_cam
 	4011_gz_lawnmower
-	4012_gz_rover_ackermann
-	4013_gz_x500_lidar
-	4014_gz_x500_mono_cam_down
-	4015_gz_r1_rover_mecanum
 	4099_gz_x500_custom_cam
 
 	6011_gazebo-classic_typhoon_h480

--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -93,6 +93,7 @@ if(gz-transport_FOUND)
 		windy
 		baylands
   		lawn
+		custom_aruco
 	)
 
 	# find corresponding airframes


### PR DESCRIPTION
### Related PRs
https://github.com/novitai/acton/pull/13
https://github.com/hugo2410/PX4-gazebo-models/pull/1

## What?
Adds new airframe with a custom camera and new world which for now supports aruco markers 

## Why?
Before adding the object detection node, we need to add a camera plugin for the sim

## How?
Creates new aircraft file called x500_custom_cam, which has all the same properties as the x500 except that it has the following param set by default

[NAV_DLL_ACT](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#NAV_DLL_ACT) to 0 `disabled`
[COM_RC_IN_MODE](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#COM_RC_IN_MODE) to 4 `Stick input disabled` 
[COM_RCL_EXCEPT](https://docs.px4.io/main/en/advanced_config/parameter_reference.html#COM_RCL_EXCEPT) set bit 2 to true `Offboard`
as suggested by @beniaminopozzan https://github.com/novitai/acton/issues/4#issuecomment-2450253436

Updates CMakelist files to include new aircraft and new world and links to the new submodule's commit ([PR](https://github.com/hugo2410/PX4-gazebo-models/pull/1))


## Testing
Tested the entrypoint script on the AWS instance

## Screenshot

https://github.com/user-attachments/assets/da8950bc-e867-40ff-bb8d-c1fafa3f4952



